### PR TITLE
feat: update GitHub runner version to v2.311.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
     types: [ opened, synchronize, closed ]
 
 env:
-  RUNNER_VERSION: 2.310.2
+  RUNNER_VERSION: 2.311.0
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # github runner version
-ARG RUNNER_VERSION="2.310.2"
+ARG RUNNER_VERSION="2.311.0"
 
 # update the base packages
 RUN apt-get update -y && apt-get upgrade -y


### PR DESCRIPTION
Upgrade GitHub self-hosted runner to v2.311.0

Resolves #8 