### PR TITLE
ci: update docker publish action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "ci(actions): "
+    rebase-strategy: auto

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -64,7 +64,7 @@ jobs:
           echo "GH_RUNNER_VERSION=${{ needs.set_version.outputs.GH_RUNNER_VERSION }}" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Build Docker image
         run: >-
@@ -84,7 +84,7 @@ jobs:
           echo "GH_RUNNER_VERSION=${{ needs.set_version.outputs.GH_RUNNER_VERSION }}" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: 'Publish to GitHub Registry (tag: RUNNER_VERSION)'
         uses: elgohr/Publish-Docker-Github-Action@master

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -85,13 +85,24 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: 'Publish to GitHub Registry (tag: RUNNER_VERSION)'
-        uses: elgohr/Publish-Docker-Github-Action@master
+
+      - name: Login into GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          name: Onvox/docker-ubuntu2204-runner/docker-ubuntu2204-runner
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          buildargs: GH_RUNNER_VERSION
-          registry: docker.pkg.github.com
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: 'Build and Publish to GitHub Registry (tag: ${{ env.GH_RUNNER_VERSION }})'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
           tags: ${{ env.GH_RUNNER_VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Update docker publish action to remove dependency on legacy action with deprecation issues.