### PR TITLE
ci: add packages write permission to workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -77,6 +77,8 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     needs: set_version
     steps:
       - name: Set version


### PR DESCRIPTION
Chore - add missing `packages: write` permission to publish workflow.